### PR TITLE
Added Optional RHS arguments in ForwardEuler

### DIFF
--- a/forward_euler/ForwardEuler.py
+++ b/forward_euler/ForwardEuler.py
@@ -63,7 +63,7 @@ class ForwardEuler:
                  h optionally holds the requested step size (if it is not
                      provided then the stored value will be used)
                  args holds optional equation parameters used when evaluating
-                     the RHS
+                     the RHS.
         Outputs: Y holds the computed solution at all tspan values,
                      [y(t0), y(t1), ..., y(tf)]
                  success = True if the solver traversed the interval,

--- a/forward_euler/ForwardEuler.py
+++ b/forward_euler/ForwardEuler.py
@@ -28,15 +28,16 @@ class ForwardEuler:
         # internal data
         self.steps = 0
 
-    def forward_euler_step(self, t, y):
+    def forward_euler_step(self, t, y, args=()):
         """
-        Usage: t, y, success = forward_euler_step(t, y)
+        Usage: t, y, success = forward_euler_step(t, y, args)
 
         Utility routine to take a single forward Euler time step,
         where the inputs (t,y) are overwritten by the updated versions.
+        args is used for optional parameters of your RHS.
         If success==True then the step succeeded; otherwise it failed.
         """
-        y += self.h * self.f(t,y)
+        y += self.h * self.f(t,y,*args)
         t += self.h
         self.steps += 1
         return t, y, True
@@ -49,9 +50,9 @@ class ForwardEuler:
         """ Returns the accumulated number of steps """
         return self.steps
 
-    def Evolve(self, tspan, y0, h=0.0):
+    def Evolve(self, tspan, y0, h=0.0, args=()):
         """
-        Usage: Y, success = Evolve(tspan, y0, h)
+        Usage: Y, success = Evolve(tspan, y0, h, args)
 
         The fixed-step forward Euler evolution routine
 
@@ -61,6 +62,8 @@ class ForwardEuler:
                  y holds the initial condition, y(t0)
                  h optionally holds the requested step size (if it is not
                      provided then the stored value will be used)
+                 args holds optional equation parameters used when evaluating
+                     the RHS
         Outputs: Y holds the computed solution at all tspan values,
                      [y(t0), y(t1), ..., y(tf)]
                  success = True if the solver traversed the interval,
@@ -100,7 +103,7 @@ class ForwardEuler:
             for n in range(N):
 
                 # perform forward Euler update
-                t, y, success = self.forward_euler_step(t, y)
+                t, y, success = self.forward_euler_step(t, y, args)
                 if (not success):
                     print("forward_euler error in time step at t =", t)
                     return Y, False

--- a/forward_euler/driver_fwd_euler.py
+++ b/forward_euler/driver_fwd_euler.py
@@ -25,9 +25,10 @@ def f1(t,y):
 def ytrue1(t):
     """ Analytical solution """
     return np.array([np.exp(-t)])
-def f2(t,y):
-    """ ODE RHS function """
-    return np.array([(y[0]+t*t-2.0)/(t+1.0)])
+
+def f2(t,y, alpha, beta):
+    """ ODE RHS function (with parameters alpha and beta)"""
+    return np.array([(alpha*y[0]+t*t-2.0*beta)/(t+1.0)])
 def ytrue2(t):
     """ Analytical solution """
     return np.array([t*t + 2.0*t + 2.0 - 2.0*(t+1.0)*np.log(t+1.0)])
@@ -77,7 +78,14 @@ for idx, h in enumerate(hvals):
     y0 = Y2true[0,:]
     print("  h = ", h, ":")
     FE2.reset()
-    Y, success = FE2.Evolve(tspan, y0, h)
+    alpha = 1.0
+    beta = 1.0
+    # Here when calling our rhs (f2) notice we have parameters alpha
+    # and beta. At within the ForwardEuler.py we will call f2(t,y,*args)
+    # Here *(<tuple>) is the unpacking operator. This will unpack the args tuple into
+    # the third and fourth arguments of f2. This is the same implementation
+    # as in standard python ODE packages.
+    Y, success = FE2.Evolve(tspan, y0, h, args=(alpha, beta))
 
     # output solution, errors, and overall error
     Yerr = np.abs(Y-Y2true)


### PR DESCRIPTION
This will allow for optional parameters to our RHS fuction. Example:
```python
def rhs(t, y, alpha, beta):
    """ ODE RHS function """
    f1 = alpha - y[1]
    f2 = beta*y[0]
    return np.array([f1,f2])

FE = ForwardEuler(rhs)
Y, _ = FE.Evolve(tspan, y0, h, args=(alpha, beta)) 
```

 Changes to be committed:
	modified:   forward_euler/ForwardEuler.py